### PR TITLE
Fix tests and provide sample GitHub actions

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,46 @@
+# A sample CI/CD workflow for Fensak rules. This workflow will:
+# - Check if the code is formatted properly using `deno fmt`.
+# - Lint the code using `deno lint`.
+# - Run the tests using `deno test` and output a junit report.
+# - Process the junit report and upload to GitHub Actions so that it can be viewed.
+
+name: lint-test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  checks: write
+  contents: read
+
+jobs:
+  # Run linter and tests against Fensak rules
+  linttest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+
+      - uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31 # v1.1.2
+        with:
+          deno-version: v1.37.1
+
+      - name: fmt
+        run: deno fmt --check
+
+      - name: lint
+        run: deno lint
+
+      - name: test
+        run: deno test --allow-env --allow-read --allow-net --reporter=junit --junit-path=./report.xml
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: report
+        uses: mikepenz/action-junit-report@75b84e78b3f0aaea7ed7cf8d1d100d7f97f963ec # v4.0.0
+        if: always()
+        with:
+          report_paths: "report.xml"
+          check_name: "deno test report"

--- a/rules/sample_test.ts
+++ b/rules/sample_test.ts
@@ -30,7 +30,7 @@ Deno.test("No changes should be approved", async () => {
 
 Deno.test("Changes only to README should be approved", async () => {
   // View PR at
-  // https://github.com/fensak-io/dotgithub-template/pull/1
+  // https://github.com/fensak-io/dotfensak-template/pull/1
   const patches = await patchFromGitHubPullRequest(octokit, testRepo, 1);
   const result = await runRule(ruleFn, patches.patchList, opts);
   assert(result.approve);
@@ -38,7 +38,7 @@ Deno.test("Changes only to README should be approved", async () => {
 
 Deno.test("Changes to non-README files should be rejected", async () => {
   // View PR at
-  // https://github.com/fensak-io/dotgithub-template/pull/2
+  // https://github.com/fensak-io/dotfensak-template/pull/2
   const patches = await patchFromGitHubPullRequest(octokit, testRepo, 2);
   const result = await runRule(ruleFn, patches.patchList, opts);
   assert(!result.approve);
@@ -46,8 +46,8 @@ Deno.test("Changes to non-README files should be rejected", async () => {
 
 Deno.test("Change containing more than one file should be rejected", async () => {
   // View PR at
-  // https://github.com/fensak-io/dotgithub-template/pull/3
-  const patches = await patchFromGitHubPullRequest(octokit, testRepo, 3);
+  // https://github.com/fensak-io/dotfensak-template/pull/4
+  const patches = await patchFromGitHubPullRequest(octokit, testRepo, 4);
   const result = await runRule(ruleFn, patches.patchList, opts);
   assert(!result.approve);
 });


### PR DESCRIPTION
NOTE: The GitHub actions are expected to fail right now since `fensak-io/fensak` is not public yet, but will start to pass once we are ready to launch.